### PR TITLE
fix unexpected 'Invalid page range' exception for GetAllPagesAsync methods

### DIFF
--- a/ShipStation4Net/Clients/Customers.cs
+++ b/ShipStation4Net/Clients/Customers.cs
@@ -54,7 +54,10 @@ namespace ShipStation4Net.Clients
 
             var pageOne = await GetDataAsync<PaginatedResponse<Customer>>((CustomersFilter)filter).ConfigureAwait(false);
             items.AddRange(pageOne.Items);
-            items.AddRange(await GetPageRangeAsync(2, pageOne.TotalPages, filter.PageSize, filter).ConfigureAwait(false));
+			if (pageOne.TotalPages > 1)
+			{
+				items.AddRange(await GetPageRangeAsync(2, pageOne.TotalPages, filter.PageSize, filter).ConfigureAwait(false));
+			}
 
             return items;
         }

--- a/ShipStation4Net/Clients/Fulfillments.cs
+++ b/ShipStation4Net/Clients/Fulfillments.cs
@@ -40,7 +40,10 @@ namespace ShipStation4Net.Clients
 
             var pageOne = await GetDataAsync<PaginatedResponse<Fulfillment>>((FulfillmentsFilter)filter).ConfigureAwait(false);
             items.AddRange(pageOne.Items);
-            items.AddRange(await GetPageRangeAsync(2, pageOne.TotalPages, filter.PageSize, (FulfillmentsFilter)filter).ConfigureAwait(false));
+			if (pageOne.TotalPages > 1)
+			{
+				items.AddRange(await GetPageRangeAsync(2, pageOne.TotalPages, filter.PageSize, (FulfillmentsFilter)filter).ConfigureAwait(false));
+			}
 
             return items;
         }

--- a/ShipStation4Net/Clients/Orders.cs
+++ b/ShipStation4Net/Clients/Orders.cs
@@ -70,7 +70,10 @@ namespace ShipStation4Net.Clients
 
             var pageOne = await GetDataAsync<PaginatedResponse<Order>>((OrdersFilter)filter).ConfigureAwait(false);
             items.AddRange(pageOne.Items as List<Order>);
-            items.AddRange(await GetPageRangeAsync(2, pageOne.TotalPages, filter.PageSize, filter).ConfigureAwait(false));
+			if (pageOne.TotalPages > 1)
+			{
+				items.AddRange(await GetPageRangeAsync(2, pageOne.TotalPages, filter.PageSize, filter).ConfigureAwait(false));
+			}
 
             return items;
         }

--- a/ShipStation4Net/Clients/Products.cs
+++ b/ShipStation4Net/Clients/Products.cs
@@ -51,7 +51,10 @@ namespace ShipStation4Net.Clients
 
             var pageOne = await GetDataAsync<PaginatedResponse<Product>>((ProductsFilter)filter).ConfigureAwait(false);
             items.AddRange(pageOne.Items);
-            items.AddRange(await GetPageRangeAsync(2, pageOne.TotalPages, filter.PageSize, (ProductsFilter)filter).ConfigureAwait(false));
+			if (pageOne.TotalPages > 1)
+			{
+				items.AddRange(await GetPageRangeAsync(2, pageOne.TotalPages, filter.PageSize, (ProductsFilter)filter).ConfigureAwait(false));
+			}
 
             return items;
         }

--- a/ShipStation4Net/Clients/Shipments.cs
+++ b/ShipStation4Net/Clients/Shipments.cs
@@ -50,7 +50,10 @@ namespace ShipStation4Net.Clients
 
             var pageOne = await GetDataAsync<PaginatedResponse<Shipment>>((ShipmentsFilter)filter).ConfigureAwait(false);
             items.AddRange(pageOne.Items);
-            items.AddRange(await GetPageRangeAsync(2, pageOne.TotalPages, filter.PageSize, (ShipmentsFilter)filter).ConfigureAwait(false));
+			if (pageOne.TotalPages > 1)
+			{
+				items.AddRange(await GetPageRangeAsync(2, pageOne.TotalPages, filter.PageSize, (ShipmentsFilter)filter).ConfigureAwait(false));
+			}
 
             return items;
         }


### PR DESCRIPTION
Just discovered that if pageOne.TotalPages = 1, it still tries to trigger GetPageRangeAsync method which causing 'Invalid page range' exception, because 'start > end'