### PR TITLE
should use Pages, not TotalPages when paging thru

### DIFF
--- a/ShipStation4Net/Clients/Customers.cs
+++ b/ShipStation4Net/Clients/Customers.cs
@@ -54,9 +54,9 @@ namespace ShipStation4Net.Clients
 
             var pageOne = await GetDataAsync<PaginatedResponse<Customer>>((CustomersFilter)filter).ConfigureAwait(false);
             items.AddRange(pageOne.Items);
-			if (pageOne.TotalPages > 1)
+			if (pageOne.Pages > 1)
 			{
-				items.AddRange(await GetPageRangeAsync(2, pageOne.TotalPages, filter.PageSize, filter).ConfigureAwait(false));
+				items.AddRange(await GetPageRangeAsync(2, pageOne.Pages, filter.PageSize, filter).ConfigureAwait(false));
 			}
 
             return items;

--- a/ShipStation4Net/Clients/Fulfillments.cs
+++ b/ShipStation4Net/Clients/Fulfillments.cs
@@ -40,9 +40,9 @@ namespace ShipStation4Net.Clients
 
             var pageOne = await GetDataAsync<PaginatedResponse<Fulfillment>>((FulfillmentsFilter)filter).ConfigureAwait(false);
             items.AddRange(pageOne.Items);
-			if (pageOne.TotalPages > 1)
+			if (pageOne.Pages > 1)
 			{
-				items.AddRange(await GetPageRangeAsync(2, pageOne.TotalPages, filter.PageSize, (FulfillmentsFilter)filter).ConfigureAwait(false));
+				items.AddRange(await GetPageRangeAsync(2, pageOne.Pages, filter.PageSize, (FulfillmentsFilter)filter).ConfigureAwait(false));
 			}
 
             return items;

--- a/ShipStation4Net/Clients/Orders.cs
+++ b/ShipStation4Net/Clients/Orders.cs
@@ -50,7 +50,7 @@ namespace ShipStation4Net.Clients
 
             yield return pageOne.Items;
 
-            for (int i = 2; i <= pageOne.TotalPages; i++)
+            for (int i = 2; i <= pageOne.Pages; i++)
             {
                 var currentPage = GetPageAsync(i, filter.PageSize, (OrdersFilter)filter).Result;
                 yield return currentPage;
@@ -70,9 +70,9 @@ namespace ShipStation4Net.Clients
 
             var pageOne = await GetDataAsync<PaginatedResponse<Order>>((OrdersFilter)filter).ConfigureAwait(false);
             items.AddRange(pageOne.Items as List<Order>);
-			if (pageOne.TotalPages > 1)
+			if (pageOne.Pages > 1)
 			{
-				items.AddRange(await GetPageRangeAsync(2, pageOne.TotalPages, filter.PageSize, filter).ConfigureAwait(false));
+				items.AddRange(await GetPageRangeAsync(2, pageOne.Pages, filter.PageSize, filter).ConfigureAwait(false));
 			}
 
             return items;

--- a/ShipStation4Net/Clients/Products.cs
+++ b/ShipStation4Net/Clients/Products.cs
@@ -51,9 +51,9 @@ namespace ShipStation4Net.Clients
 
             var pageOne = await GetDataAsync<PaginatedResponse<Product>>((ProductsFilter)filter).ConfigureAwait(false);
             items.AddRange(pageOne.Items);
-			if (pageOne.TotalPages > 1)
+			if (pageOne.Pages > 1)
 			{
-				items.AddRange(await GetPageRangeAsync(2, pageOne.TotalPages, filter.PageSize, (ProductsFilter)filter).ConfigureAwait(false));
+				items.AddRange(await GetPageRangeAsync(2, pageOne.Pages, filter.PageSize, (ProductsFilter)filter).ConfigureAwait(false));
 			}
 
             return items;

--- a/ShipStation4Net/Clients/Shipments.cs
+++ b/ShipStation4Net/Clients/Shipments.cs
@@ -50,9 +50,9 @@ namespace ShipStation4Net.Clients
 
             var pageOne = await GetDataAsync<PaginatedResponse<Shipment>>((ShipmentsFilter)filter).ConfigureAwait(false);
             items.AddRange(pageOne.Items);
-			if (pageOne.TotalPages > 1)
+			if (pageOne.Pages > 1)
 			{
-				items.AddRange(await GetPageRangeAsync(2, pageOne.TotalPages, filter.PageSize, (ShipmentsFilter)filter).ConfigureAwait(false));
+				items.AddRange(await GetPageRangeAsync(2, pageOne.Pages, filter.PageSize, (ShipmentsFilter)filter).ConfigureAwait(false));
 			}
 
             return items;


### PR DESCRIPTION
bug fix to something I just discovered while troubleshooting performance for large client.
basically, when you filter list of  orders, you should iterate thru Pages (which identifies number of pages in filtered collection). TotalPages will tell how many pages in entire collection of orders/shipments/..
so if you filter & page thru pages between *Pages* .. *TotalPages* numbers it will return nothing, and will waste api calls (which are limited per minute)