### PR TITLE
Multiple issues fixed

### DIFF
--- a/ShipStation4Net/ClientBase.cs
+++ b/ShipStation4Net/ClientBase.cs
@@ -36,6 +36,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace ShipStation4Net
@@ -212,12 +213,14 @@ namespace ShipStation4Net
 
 		private async Task<IRestResponse<T>> ExecuteRequest<T>(HttpRequestMessage message)
 		{
-			var credentials = new NetworkCredential(Configuration.UserName, Configuration.UserApiKey);
-			var handler = new HttpClientHandler { Credentials = credentials };
 			IRestResponse<T> response;
 
-			using (var client = new HttpClient(handler))
+			using (var client = new HttpClient())
 			{
+				//set basic authorization explicitly (which prevents additional extra call each time that ends up with 401 error)
+				var byteArray = Encoding.UTF8.GetBytes($"{Configuration.UserName}:{Configuration.UserApiKey}");
+				client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
+				
 				client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 				client.BaseAddress = Configuration.BaseUri;
 

--- a/ShipStation4Net/Clients/Orders.cs
+++ b/ShipStation4Net/Clients/Orders.cs
@@ -28,279 +28,283 @@ using System.Threading.Tasks;
 
 namespace ShipStation4Net.Clients
 {
-    public class Orders : ClientBase, IGetsPaginatedResponses<Order>, ICreates<Order>, IGets<Order>
-    {
-        public Orders(Configuration configuration) : base(configuration)
-        {
-            BaseUri = "orders";
-        }
+	public class Orders : ClientBase, IGetsPaginatedResponses<Order>, ICreates<Order>, IGets<Order>
+	{
+		public Orders(Configuration configuration) : base(configuration)
+		{
+			BaseUri = "orders";
+		}
 
-        /// <summary>
-        /// Obtains a list of order pages that match the specified criteria. All of the available filters are optional. They do not need to be 
-        /// included in the URL. The filter is created just for the particular Orders return type.
-        /// </summary>
-        /// <param name="filter">An OrdersFilter</param>
-        /// <returns>A list of order pages filtered by the supplied parameters.</returns>
-        public IEnumerable<IEnumerable<Order>> GetAllPages(IFilter filter = null)
-        {
-            var items = new List<Order>();
-            filter = filter ?? new OrdersFilter();
+		/// <summary>
+		/// Obtains a list of order pages that match the specified criteria. All of the available filters are optional. They do not need to be 
+		/// included in the URL. The filter is created just for the particular Orders return type.
+		/// </summary>
+		/// <param name="filter">An OrdersFilter</param>
+		/// <returns>A list of order pages filtered by the supplied parameters.</returns>
+		public IEnumerable<IEnumerable<Order>> GetAllPages(IFilter filter = null)
+		{
+			var items = new List<Order>();
+			filter = filter ?? new OrdersFilter();
 
-            var pageOne = GetDataAsync<PaginatedResponse<Order>>((OrdersFilter)filter).Result;
+			var pageOne = GetDataAsync<PaginatedResponse<Order>>((OrdersFilter)filter).Result;
 
-            yield return pageOne.Items;
+			yield return pageOne.Items;
 
-            for (int i = 2; i <= pageOne.Pages; i++)
-            {
-                var currentPage = GetPageAsync(i, filter.PageSize, (OrdersFilter)filter).Result;
-                yield return currentPage;
-            }
-        }
+			for (int i = 2; i <= pageOne.Pages; i++)
+			{
+				var currentPage = GetPageAsync(i, filter.PageSize, (OrdersFilter)filter).Result;
+				yield return currentPage;
+			}
+		}
 
-        /// <summary>
-        /// Obtains a list of orders that match the specified criteria. All of the available filters are optional. They do not need to be 
-        /// included in the URL. The filter is created just for the particular Orders return type.
-        /// </summary>
-        /// <param name="filter">An OrdersFilter</param>
-        /// <returns>A list of orders filtered by the supplied parameters.</returns>
-        public async Task<IList<Order>> GetAllPagesAsync(IFilter filter = null)
-        {
-            var items = new List<Order>();
-            filter = filter ?? new OrdersFilter();
+		/// <summary>
+		/// Obtains a list of orders that match the specified criteria. All of the available filters are optional. They do not need to be 
+		/// included in the URL. The filter is created just for the particular Orders return type.
+		/// </summary>
+		/// <param name="filter">An OrdersFilter</param>
+		/// <returns>A list of orders filtered by the supplied parameters.</returns>
+		public async Task<IList<Order>> GetAllPagesAsync(IFilter filter = null)
+		{
+			var items = new List<Order>();
+			filter = filter ?? new OrdersFilter();
 
-            var pageOne = await GetDataAsync<PaginatedResponse<Order>>((OrdersFilter)filter).ConfigureAwait(false);
-            items.AddRange(pageOne.Items as List<Order>);
+			var pageOne = await GetDataAsync<PaginatedResponse<Order>>((OrdersFilter)filter).ConfigureAwait(false);
+			items.AddRange(pageOne.Items as List<Order>);
 			if (pageOne.Pages > 1)
 			{
 				items.AddRange(await GetPageRangeAsync(2, pageOne.Pages, filter.PageSize, filter).ConfigureAwait(false));
 			}
 
-            return items;
-        }
+			return items;
+		}
 
-        public async Task<IList<Order>> GetPageRangeAsync(int start, int end, int pageSize = 100, IFilter filter = null)
-        {
-            if (start < 1) throw new ArgumentException(nameof(start), "Cannot be a negative or zero");
-            if (start > end) throw new ArgumentException(nameof(end), "Invalid page range");
-            if (pageSize < 1 || pageSize > 500) throw new ArgumentOutOfRangeException(nameof(pageSize), "Should be in range 1..500");
+		public async Task<IList<Order>> GetPageRangeAsync(int start, int end, int pageSize = 100, IFilter filter = null)
+		{
+			if (start < 1) throw new ArgumentException(nameof(start), "Cannot be a negative or zero");
+			if (start > end) throw new ArgumentException(nameof(end), "Invalid page range");
+			if (pageSize < 1 || pageSize > 500) throw new ArgumentOutOfRangeException(nameof(pageSize), "Should be in range 1..500");
 
-            var items = new List<Order>();
+			var items = new List<Order>();
 
-            for (int i = start; i <= end; i++)
-            {
-                items.AddRange(await GetPageAsync(i, pageSize, (OrdersFilter)filter).ConfigureAwait(false));
-            }
-            return items;
-        }
+			for (int i = start; i <= end; i++)
+			{
+				items.AddRange(await GetPageAsync(i, pageSize, (OrdersFilter)filter).ConfigureAwait(false));
+			}
+			return items;
+		}
 
-        public async Task<IList<Order>> GetPageAsync(int page, int pageSize = 100, IFilter filter = null)
-        {
-            if (page < 1) throw new ArgumentException(nameof(page), "Cannot be a negative or zero");
-            if (pageSize < 1 || pageSize > 500) throw new ArgumentOutOfRangeException(nameof(pageSize), "Should be in range 1..500");
+		public async Task<IList<Order>> GetPageAsync(int page, int pageSize = 100, IFilter filter = null)
+		{
+			if (page < 1) throw new ArgumentException(nameof(page), "Cannot be a negative or zero");
+			if (pageSize < 1 || pageSize > 500) throw new ArgumentOutOfRangeException(nameof(pageSize), "Should be in range 1..500");
 
-            filter = filter ?? new OrdersFilter();
+			filter = filter ?? new OrdersFilter();
 
-            filter.Page = page;
-            filter.PageSize = pageSize;
+			filter.Page = page;
+			filter.PageSize = pageSize;
 
-            var response = await GetDataAsync<PaginatedResponse<Order>>((OrdersFilter)filter).ConfigureAwait(false);
-            return response.Items;
-        }
+			var response = await GetDataAsync<PaginatedResponse<Order>>((OrdersFilter)filter).ConfigureAwait(false);
+			return response.Items;
+		}
 
-        /// <summary>
-        /// If the orderKey is specified, the method becomes idempotent and the existing order with that key will be updated. Note: Only 
-        /// orders in an open status in ShipStation (awaiting_payment,awaiting_shipment, and on_hold) can be updated through this method. 
-        /// cancelled and shipped are locked from modification through the API. 
-        /// </summary>
-        /// <param name="newItem">A newly created order</param>
-        /// <returns>The order with fields assigned to it by the API.</returns>
-        public Task<Order> CreateAsync(Order newItem)
-        {
-            return PostDataAsync("createorder", newItem);
-        }
+		/// <summary>
+		/// If the orderKey is specified, the method becomes idempotent and the existing order with that key will be updated. Note: Only 
+		/// orders in an open status in ShipStation (awaiting_payment,awaiting_shipment, and on_hold) can be updated through this method. 
+		/// cancelled and shipped are locked from modification through the API. 
+		/// </summary>
+		/// <param name="newItem">A newly created order</param>
+		/// <returns>The order with fields assigned to it by the API.</returns>
+		public Task<Order> CreateAsync(Order newItem)
+		{
+			if (newItem?.OrderNumber != null && newItem.OrderNumber.Length > 50)
+			{
+				throw new ArgumentException("Order Number cannot exceed 50 symbols. Shipstation will truncate it without error", nameof(newItem));
+			}
+			return PostDataAsync("createorder", newItem);
+		}
 
-        /// <summary>
-        /// An alias of CreateAsync because updates are on the same endpoint as creates.
-        /// </summary>
-        /// <param name="item">The item to update.</param>
-        /// <returns>The updated order.</returns>
-        public Task<Order> UpdateAsync(Order item)
-        {
-            return CreateAsync(item);
-        }
+		/// <summary>
+		/// An alias of CreateAsync because updates are on the same endpoint as creates.
+		/// </summary>
+		/// <param name="item">The item to update.</param>
+		/// <returns>The updated order.</returns>
+		public Task<Order> UpdateAsync(Order item)
+		{
+			return CreateAsync(item);
+		}
 
-        /// <summary>
-        /// Retrieves a single order from the database.
-        /// </summary>
-        /// <param name="id">The id of the order to retrieve.</param>
-        /// <returns>The order specified by the id.</returns>
-        public Task<Order> GetAsync(int id)
-        {
-            return GetDataAsync<Order>(id);
-        }
+		/// <summary>
+		/// Retrieves a single order from the database.
+		/// </summary>
+		/// <param name="id">The id of the order to retrieve.</param>
+		/// <returns>The order specified by the id.</returns>
+		public Task<Order> GetAsync(int id)
+		{
+			return GetDataAsync<Order>(id);
+		}
 
-        /// <summary>
-        /// Removes order from ShipStation's UI. Note this is a "soft" delete action so the order will still exist in the database, but 
-        /// will be set to inactive
-        /// </summary>
-        /// <param name="id">The id of the order to delete.</param>
-        /// <returns>A boolean representing whether or not the delete was successful.</returns>
-        public Task<bool> DeleteAsync(int id)
-        {
-            return DeleteDataAsync(id);
-        }
+		/// <summary>
+		/// Removes order from ShipStation's UI. Note this is a "soft" delete action so the order will still exist in the database, but 
+		/// will be set to inactive
+		/// </summary>
+		/// <param name="id">The id of the order to delete.</param>
+		/// <returns>A boolean representing whether or not the delete was successful.</returns>
+		public Task<bool> DeleteAsync(int id)
+		{
+			return DeleteDataAsync(id);
+		}
 
-        /// <summary>
-        /// Creates a shipping label for a given order. The labelData field returned in the response is a base64 encoded PDF value. Simply 
-        /// decode and save the output as a PDF file to retrieve a printable label. 
-        /// </summary>
-        /// <param name="userId">The user id to assign</param>
-        /// <param name="orderIds">The list of order ids to assign to the user</param>
-        /// <returns>A boolean representing whether or not the request was successful.</returns>
-        public async Task<bool> AssignUserToOrderAsync(string userId, IList<int> orderIds)
-        {
-            var assignUserRequest = new JObject();
-            assignUserRequest["orderIds"] = new JArray(orderIds);
-            assignUserRequest["userId"] = userId;
+		/// <summary>
+		/// Creates a shipping label for a given order. The labelData field returned in the response is a base64 encoded PDF value. Simply 
+		/// decode and save the output as a PDF file to retrieve a printable label. 
+		/// </summary>
+		/// <param name="userId">The user id to assign</param>
+		/// <param name="orderIds">The list of order ids to assign to the user</param>
+		/// <returns>A boolean representing whether or not the request was successful.</returns>
+		public async Task<bool> AssignUserToOrderAsync(string userId, IList<int> orderIds)
+		{
+			var assignUserRequest = new JObject();
+			assignUserRequest["orderIds"] = new JArray(orderIds);
+			assignUserRequest["userId"] = userId;
 
-            var response = await PostDataAsync<JObject, SuccessResponse>("assignuser", assignUserRequest).ConfigureAwait(false);
+			var response = await PostDataAsync<JObject, SuccessResponse>("assignuser", assignUserRequest).ConfigureAwait(false);
 
-            return response.Success;
-        }
+			return response.Success;
+		}
 
-        /// <summary>
-        /// Creates a shipping label for a given order. The labelData field returned in the response is a base64 encoded PDF value. Simply
-        /// decode and save the output as a PDF file to retrieve a printable label. 
-        /// </summary>
-        /// <param name="order">The order to create a label from.</param>
-        /// <returns>A Shipment with the label data.</returns>
-        public Task<Shipment> CreateLabelFromOrderAsync(Order order)
-        {
-            return PostDataAsync<Order, Shipment>("createlabelfororder", order);
-        }
+		/// <summary>
+		/// Creates a shipping label for a given order. The labelData field returned in the response is a base64 encoded PDF value. Simply
+		/// decode and save the output as a PDF file to retrieve a printable label. 
+		/// </summary>
+		/// <param name="order">The order to create a label from.</param>
+		/// <returns>A Shipment with the label data.</returns>
+		public Task<Shipment> CreateLabelFromOrderAsync(Order order)
+		{
+			return PostDataAsync<Order, Shipment>("createlabelfororder", order);
+		}
 
-        /// <summary>
-        /// This method will change the status of the given order to On Hold until the date specified, when the status will automatically 
-        /// change to Awaiting Shipment.
-        /// </summary>
-        /// <param name="orderId">The id of the order to put on hold.</param>
-        /// <param name="holdUntilDate">Date when order is moved from on_hold status to awaiting_shipment.</param>
-        /// <returns>A response that represents whether or not the request was completed successfully.</returns>
-        public async Task<bool> HoldOrderUntilAsync(int orderId, DateTime holdUntilDate)
-        {
-            var holdOrderRequest = new JObject();
-            holdOrderRequest["orderId"] = orderId;
-            holdOrderRequest["holdUntilDate"] = holdUntilDate.ToString();
+		/// <summary>
+		/// This method will change the status of the given order to On Hold until the date specified, when the status will automatically 
+		/// change to Awaiting Shipment.
+		/// </summary>
+		/// <param name="orderId">The id of the order to put on hold.</param>
+		/// <param name="holdUntilDate">Date when order is moved from on_hold status to awaiting_shipment.</param>
+		/// <returns>A response that represents whether or not the request was completed successfully.</returns>
+		public async Task<bool> HoldOrderUntilAsync(int orderId, DateTime holdUntilDate)
+		{
+			var holdOrderRequest = new JObject();
+			holdOrderRequest["orderId"] = orderId;
+			holdOrderRequest["holdUntilDate"] = holdUntilDate.ToString();
 
-            var response = await PostDataAsync<JObject, SuccessResponse>("holduntil", holdOrderRequest).ConfigureAwait(false);
+			var response = await PostDataAsync<JObject, SuccessResponse>("holduntil", holdOrderRequest).ConfigureAwait(false);
 
-            return response.Success;
-        }
+			return response.Success;
+		}
 
-        /// <summary>
-        /// Lists all orders that match the specified status and tag ID.
-        /// </summary>
-        /// <param name="tagId">ID of the tag.Call Accounts/ListTags to obtain a list of tags for this account.</param>
-        /// <param name="orderStatus">
-        /// The order's status.
-        /// Possible values:
-        /// awaiting_payment , awaiting_shipment , pending_fulfillment , shipped , on_hold , cancelled. </param>
-        /// <param name="page">
-        /// Page number
-        /// Default: 1.
-        /// </param>
-        /// <param name="pageSize">
-        /// Requested page size.Max value is 500.
-        /// Default: 100. </param>
-        /// <returns>All orders that match the specified status and tag ID.</returns>
-        public async Task<IList<Order>> ListOrdersByTagAsync(int tagId, OrderStatus orderStatus, int page = 1, int pageSize = 100)
-        {
-            var filter = new OrdersByTagFilter
-            {
-                TagId = tagId,
-                OrderStatus = orderStatus,
-                Page = page,
-                PageSize = pageSize
-            };
+		/// <summary>
+		/// Lists all orders that match the specified status and tag ID.
+		/// </summary>
+		/// <param name="tagId">ID of the tag.Call Accounts/ListTags to obtain a list of tags for this account.</param>
+		/// <param name="orderStatus">
+		/// The order's status.
+		/// Possible values:
+		/// awaiting_payment , awaiting_shipment , pending_fulfillment , shipped , on_hold , cancelled. </param>
+		/// <param name="page">
+		/// Page number
+		/// Default: 1.
+		/// </param>
+		/// <param name="pageSize">
+		/// Requested page size.Max value is 500.
+		/// Default: 100. </param>
+		/// <returns>All orders that match the specified status and tag ID.</returns>
+		public async Task<IList<Order>> ListOrdersByTagAsync(int tagId, OrderStatus orderStatus, int page = 1, int pageSize = 100)
+		{
+			var filter = new OrdersByTagFilter
+			{
+				TagId = tagId,
+				OrderStatus = orderStatus,
+				Page = page,
+				PageSize = pageSize
+			};
 
-            var response = await GetDataAsync<PaginatedResponse<Order>>("listbytag", filter).ConfigureAwait(false);
+			var response = await GetDataAsync<PaginatedResponse<Order>>("listbytag", filter).ConfigureAwait(false);
 
-            return response.Items;
-        }
+			return response.Items;
+		}
 
-        /// <summary>
-        /// Marks an order as shipped without creating a label in ShipStation. Has its own special request.
-        /// </summary>
-        /// <param name="request">A variant of the order object</param>
-        /// <returns>A response that contains the order id and number.</returns>
-        public Task<MarkOrderAsShippedResponse> MarkOrderAsShippedAsync(MarkOrderAsShippedRequest request)
-        {
-            return PostDataAsync<MarkOrderAsShippedRequest, MarkOrderAsShippedResponse>("markasshipped", request);
-        }
+		/// <summary>
+		/// Marks an order as shipped without creating a label in ShipStation. Has its own special request.
+		/// </summary>
+		/// <param name="request">A variant of the order object</param>
+		/// <returns>A response that contains the order id and number.</returns>
+		public Task<MarkOrderAsShippedResponse> MarkOrderAsShippedAsync(MarkOrderAsShippedRequest request)
+		{
+			return PostDataAsync<MarkOrderAsShippedRequest, MarkOrderAsShippedResponse>("markasshipped", request);
+		}
 
-        /// <summary>
-        /// Adds a tag to the specified order.
-        /// </summary>
-        /// <param name="orderId">Identifies the order whose tag will be added.</param>
-        /// <param name="tagId">Identifies the tag to add.</param>
-        /// <returns>A response representing whether or not the request was successful.</returns>
-        public async Task<bool> AddTagToOrderAsync(int orderId, int tagId)
-        {
-            var addTagRequest = new JObject();
-            addTagRequest["orderId"] = orderId;
-            addTagRequest["tagId"] = tagId;
+		/// <summary>
+		/// Adds a tag to the specified order.
+		/// </summary>
+		/// <param name="orderId">Identifies the order whose tag will be added.</param>
+		/// <param name="tagId">Identifies the tag to add.</param>
+		/// <returns>A response representing whether or not the request was successful.</returns>
+		public async Task<bool> AddTagToOrderAsync(int orderId, int tagId)
+		{
+			var addTagRequest = new JObject();
+			addTagRequest["orderId"] = orderId;
+			addTagRequest["tagId"] = tagId;
 
-            var response = await PostDataAsync<JObject, SuccessResponse>("addtag", addTagRequest).ConfigureAwait(false);
+			var response = await PostDataAsync<JObject, SuccessResponse>("addtag", addTagRequest).ConfigureAwait(false);
 
-            return response.Success;
-        }
+			return response.Success;
+		}
 
-        /// <summary>
-        /// Removes a tag from the specified order. 
-        /// </summary>
-        /// <param name="orderId">Identifies the order whose tag will be removed.</param>
-        /// <param name="tagId"></param>
-        /// <returns>A response that represents whether or not the request was successful.</returns>
-        public async Task<bool> RemoveTagFromOrderAsync(int orderId, int tagId)
-        {
-            var removeTagRequest = new JObject();
-            removeTagRequest["orderId"] = orderId;
-            removeTagRequest["tagId"] = tagId;
+		/// <summary>
+		/// Removes a tag from the specified order. 
+		/// </summary>
+		/// <param name="orderId">Identifies the order whose tag will be removed.</param>
+		/// <param name="tagId"></param>
+		/// <returns>A response that represents whether or not the request was successful.</returns>
+		public async Task<bool> RemoveTagFromOrderAsync(int orderId, int tagId)
+		{
+			var removeTagRequest = new JObject();
+			removeTagRequest["orderId"] = orderId;
+			removeTagRequest["tagId"] = tagId;
 
-            var response = await PostDataAsync<JObject, SuccessResponse>("removetag", removeTagRequest).ConfigureAwait(false);
+			var response = await PostDataAsync<JObject, SuccessResponse>("removetag", removeTagRequest).ConfigureAwait(false);
 
-            return response.Success;
-        }
+			return response.Success;
+		}
 
-        /// <summary>
-        /// This method will change the status of the given order from On Hold to Awaiting Shipment. This endpoint is used when a 
-        /// holdUntil Date is attached to an order.
-        /// </summary>
-        /// <param name="orderId">Identifies the order that will be restored to awaiting_shipment from on_hold.</param>
-        /// <returns>A response that represents whether or not the request was successful.</returns>
-        public async Task<bool> RestoreOrderFromOnHoldAsync(int orderId)
-        {
-            var restoreOrderRequest = new JObject();
-            restoreOrderRequest["orderId"] = orderId;
+		/// <summary>
+		/// This method will change the status of the given order from On Hold to Awaiting Shipment. This endpoint is used when a 
+		/// holdUntil Date is attached to an order.
+		/// </summary>
+		/// <param name="orderId">Identifies the order that will be restored to awaiting_shipment from on_hold.</param>
+		/// <returns>A response that represents whether or not the request was successful.</returns>
+		public async Task<bool> RestoreOrderFromOnHoldAsync(int orderId)
+		{
+			var restoreOrderRequest = new JObject();
+			restoreOrderRequest["orderId"] = orderId;
 
-            var response = await PostDataAsync<JObject, SuccessResponse>("restorefromhold", restoreOrderRequest).ConfigureAwait(false);
+			var response = await PostDataAsync<JObject, SuccessResponse>("restorefromhold", restoreOrderRequest).ConfigureAwait(false);
 
-            return response.Success;
-        }
+			return response.Success;
+		}
 
-        /// <summary>
-        /// Unassigns a user from an order. 
-        /// </summary>
-        /// <param name="orderIds">Identifies set of orders that will have the user unassigned. Please note that if ANY of the orders 
-        /// within the array are not found, then no orders will have their users unassigned.</param>
-        /// <returns>A response that represents whether or not the request was successful.</returns>
-        public async Task<bool> UnassignUserFromOrderAsync(IList<int> orderIds)
-        {
-            var unassignUserRequest = new JObject();
-            unassignUserRequest["orderIds"] = new JArray(orderIds);
+		/// <summary>
+		/// Unassigns a user from an order. 
+		/// </summary>
+		/// <param name="orderIds">Identifies set of orders that will have the user unassigned. Please note that if ANY of the orders 
+		/// within the array are not found, then no orders will have their users unassigned.</param>
+		/// <returns>A response that represents whether or not the request was successful.</returns>
+		public async Task<bool> UnassignUserFromOrderAsync(IList<int> orderIds)
+		{
+			var unassignUserRequest = new JObject();
+			unassignUserRequest["orderIds"] = new JArray(orderIds);
 
-            var response = await PostDataAsync<JObject, SuccessResponse>("unassignuser", unassignUserRequest).ConfigureAwait(false);
-            return response.Success;
-        }
-    }
+			var response = await PostDataAsync<JObject, SuccessResponse>("unassignuser", unassignUserRequest).ConfigureAwait(false);
+			return response.Success;
+		}
+	}
 }

--- a/ShipStation4Net/Converters/DynamicPropertyNameConverter.cs
+++ b/ShipStation4Net/Converters/DynamicPropertyNameConverter.cs
@@ -51,7 +51,8 @@ namespace ShipStation4Net.Converters
                 {
                     if (jObject[attr.PropertyName] != null)
                     {
-                        var objectToSet = jObject[attr.PropertyName].ToObject(attr.ObjectType);
+						//we should deserialize object with all conventions applied (e.g. time zone should be converted back as well)
+						var objectToSet = serializer.Deserialize(jObject[attr.PropertyName].CreateReader(), attr.ObjectType);
                         existingValue.GetType().GetProperty(prop.Name).SetValue(existingValue, objectToSet);
                     }
                 }

--- a/ShipStation4Net/Filters/ShipmentsFilter.cs
+++ b/ShipStation4Net/Filters/ShipmentsFilter.cs
@@ -63,37 +63,37 @@ namespace ShipStation4Net.Filters
         /// Returns shipments created on or after the specified createDate
         /// Example: 2015-01-01 00:00:00. 
         /// </summary>
-        public DateTime CreateDateStart { get; set; }
+        public DateTime? CreateDateStart { get; set; }
 
         /// <summary>
         /// Returns shipments created on or before the specified createDate
         /// Example: 2015-01-08 00:00:00. 
         /// </summary>
-        public DateTime CreateDateEnd { get; set; }
+        public DateTime? CreateDateEnd { get; set; }
 
         /// <summary>
         /// Returns shipments with the shipDate on or after the specified date
         /// Example: 2015-01-01. 
         /// </summary>
-        public DateTime ShipDateStart { get; set; }
+        public DateTime? ShipDateStart { get; set; }
 
         /// <summary>
         /// Returns shipments with the shipDate on or before the specified date
         /// Example: 2015-01-08. 
         /// </summary>
-        public DateTime ShipDateEnd { get; set; }
+        public DateTime? ShipDateEnd { get; set; }
 
         /// <summary>
         /// Returns shipments voided on or after the specified date
         /// Example: 2015-01-01 00:00:00. 
         /// </summary>
-        public DateTime VoidDateStart { get; set; }
+        public DateTime? VoidDateStart { get; set; }
 
         /// <summary>
         /// Returns shipments voided on or before the specified date
         /// Example: 2015-01-08 00:00:00. 
         /// </summary>
-        public DateTime VoidDateEnd { get; set; }
+        public DateTime? VoidDateEnd { get; set; }
 
         /// <summary>
         /// Specifies whether to include shipment items with results Default value: false.


### PR DESCRIPTION
- timezone converter was not working on deserialization because of DynamicPropertyNameConverter
- default DateTime deserialization to return DateTime in UTC (as majority of other packages do). and it still accepts requests in Local timezone or UTC. because of conversion from PDT to UTC there is 1hr during the year when DateTime might end up in ambiguous range & conversion between timezones will start failing - added handling for that.
- we recently had issue with duplicated orders & ShipStation was claiming that we sent 2 requests to create same order at the same time. When I was stress-testing integration & monitoring with Fiddler, I found that HttpClient makes 1st request without Authorization header, which results in 401 and then HttpClient sends another one automatically with credentials. Not sure what causes this behavior, but I changed way how credentials are passed & explicitly populated Authorize header which removed 401 requests. (Beware, that even so ShipStation documentation says that you cannot create 2 orders with same OrderKey, it turned out that you can. if you send 2 requests fast enough.. this doesn't match their documentation & their customer support didn't have any other explanation beside that we sent 2 requests within same second for same order. which clearly not possible with this implementation).
- added extra validation for orderNumber field length in request (might be there is no reason for it, but during my stress tests I saw that shipstation truncates field by 50 symbols)