### PR TITLE
Switch Order.OrderId to be long instead of int

### DIFF
--- a/ShipStation4Net.Tests/TestOrders.cs
+++ b/ShipStation4Net.Tests/TestOrders.cs
@@ -9,7 +9,7 @@ namespace ShipStation4Net.Tests
 {
     public class TestOrders : TestBase
     {
-        int testOrderId = 14920239;
+        long testOrderId = 14920239;
 
         [Fact]
         public async void TestGetOrder()

--- a/ShipStation4Net/ClientBase.cs
+++ b/ShipStation4Net/ClientBase.cs
@@ -155,6 +155,11 @@ namespace ShipStation4Net
             return GetDataAsync<T>(id.ToString(), null);
         }
 
+        protected Task<T> GetDataAsync<T>(long id)
+        {
+            return GetDataAsync<T>(id.ToString(), null);
+        }
+
         protected Task<T> PostDataAsync<T>(T data)
         {
             return PostDataAsync(BaseUri, data);
@@ -196,6 +201,11 @@ namespace ShipStation4Net
         }
 
         protected Task<bool> DeleteDataAsync(int id)
+        {
+            return DeleteDataAsync(string.Format("{0}/{1}", BaseUri, id));
+        }
+
+        protected Task<bool> DeleteDataAsync(long id)
         {
             return DeleteDataAsync(string.Format("{0}/{1}", BaseUri, id));
         }

--- a/ShipStation4Net/Clients/Customers.cs
+++ b/ShipStation4Net/Clients/Customers.cs
@@ -26,7 +26,7 @@ using ShipStation4Net.Responses;
 
 namespace ShipStation4Net.Clients
 {
-    public class Customers : ClientBase, IGets<Customer>, IGetsPaginatedResponses<Customer, CustomersFilter>
+    public class Customers : ClientBase, IGets<Customer, int>, IGetsPaginatedResponses<Customer, CustomersFilter>
     {
         public Customers(Configuration configuration) : base(configuration)
         {

--- a/ShipStation4Net/Clients/Fulfillments.cs
+++ b/ShipStation4Net/Clients/Fulfillments.cs
@@ -26,7 +26,7 @@ using System.Threading.Tasks;
 
 namespace ShipStation4Net.Clients
 {
-    public class Fulfillments : ClientBase, IGetsPaginatedResponses<Fulfillment, FulfillmentsFilter>, IGets<Fulfillment>, IGetsResourceUrlResponses<Fulfillment>
+    public class Fulfillments : ClientBase, IGetsPaginatedResponses<Fulfillment, FulfillmentsFilter>, IGets<Fulfillment, int>, IGetsResourceUrlResponses<Fulfillment>
     {
         public Fulfillments(Configuration configuration) : base(configuration)
         {

--- a/ShipStation4Net/Clients/Interfaces/IDeletes.cs
+++ b/ShipStation4Net/Clients/Interfaces/IDeletes.cs
@@ -20,8 +20,8 @@ using System.Threading.Tasks;
 
 namespace ShipStation4Net.Clients.Interfaces
 {
-    public interface IDeletes<T>
+    public interface IDeletes<T, TId>
     {
-        Task<bool> DeleteAsync(int id);
+        Task<bool> DeleteAsync(TId id);
     }
 }

--- a/ShipStation4Net/Clients/Interfaces/IGets.cs
+++ b/ShipStation4Net/Clients/Interfaces/IGets.cs
@@ -20,8 +20,8 @@ using System.Threading.Tasks;
 
 namespace ShipStation4Net.Clients.Interfaces
 {
-    public interface IGets<T>
+    public interface IGets<T, TId>
     {
-        Task<T> GetAsync(int id);
+        Task<T> GetAsync(TId id);
     }
 }

--- a/ShipStation4Net/Clients/Orders.cs
+++ b/ShipStation4Net/Clients/Orders.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 
 namespace ShipStation4Net.Clients
 {
-    public class Orders : ClientBase, IGetsPaginatedResponses<Order, OrdersFilter>, ICreates<Order>, IGets<Order>, IGetsResourceUrlResponses<Order>, IDeletes<Order>
+    public class Orders : ClientBase, IGetsPaginatedResponses<Order, OrdersFilter>, ICreates<Order>, IGets<Order, long>, IGetsResourceUrlResponses<Order>, IDeletes<Order, long>
     {
         public Orders(Configuration configuration) : base(configuration)
         {
@@ -178,7 +178,7 @@ namespace ShipStation4Net.Clients
         /// </summary>
         /// <param name="id">The id of the order to retrieve.</param>
         /// <returns>The order specified by the id.</returns>
-        public Task<Order> GetAsync(int id)
+        public Task<Order> GetAsync(long id)
         {
             return GetDataAsync<Order>(id);
         }
@@ -189,7 +189,7 @@ namespace ShipStation4Net.Clients
         /// </summary>
         /// <param name="id">The id of the order to delete.</param>
         /// <returns>A boolean representing whether or not the delete was successful.</returns>
-        public Task<bool> DeleteAsync(int id)
+        public Task<bool> DeleteAsync(long id)
         {
             return DeleteDataAsync(id);
         }
@@ -201,7 +201,7 @@ namespace ShipStation4Net.Clients
         /// <param name="userId">The user id to assign</param>
         /// <param name="orderIds">The list of order ids to assign to the user</param>
         /// <returns>A boolean representing whether or not the request was successful.</returns>
-        public async Task<bool> AssignUserToOrderAsync(string userId, IList<int> orderIds)
+        public async Task<bool> AssignUserToOrderAsync(string userId, IList<long> orderIds)
         {
             var assignUserRequest = new JObject();
             assignUserRequest["orderIds"] = new JArray(orderIds);
@@ -230,7 +230,7 @@ namespace ShipStation4Net.Clients
         /// <param name="orderId">The id of the order to put on hold.</param>
         /// <param name="holdUntilDate">Date when order is moved from on_hold status to awaiting_shipment.</param>
         /// <returns>A response that represents whether or not the request was completed successfully.</returns>
-        public async Task<bool> HoldOrderUntilAsync(int orderId, DateTime holdUntilDate)
+        public async Task<bool> HoldOrderUntilAsync(long orderId, DateTime holdUntilDate)
         {
             var holdOrderRequest = new JObject();
             holdOrderRequest["orderId"] = orderId;
@@ -288,7 +288,7 @@ namespace ShipStation4Net.Clients
         /// <param name="orderId">Identifies the order whose tag will be added.</param>
         /// <param name="tagId">Identifies the tag to add.</param>
         /// <returns>A response representing whether or not the request was successful.</returns>
-        public async Task<bool> AddTagToOrderAsync(int orderId, int tagId)
+        public async Task<bool> AddTagToOrderAsync(long orderId, int tagId)
         {
             var addTagRequest = new JObject();
             addTagRequest["orderId"] = orderId;
@@ -305,7 +305,7 @@ namespace ShipStation4Net.Clients
         /// <param name="orderId">Identifies the order whose tag will be removed.</param>
         /// <param name="tagId"></param>
         /// <returns>A response that represents whether or not the request was successful.</returns>
-        public async Task<bool> RemoveTagFromOrderAsync(int orderId, int tagId)
+        public async Task<bool> RemoveTagFromOrderAsync(long orderId, int tagId)
         {
             var removeTagRequest = new JObject();
             removeTagRequest["orderId"] = orderId;
@@ -322,7 +322,7 @@ namespace ShipStation4Net.Clients
         /// </summary>
         /// <param name="orderId">Identifies the order that will be restored to awaiting_shipment from on_hold.</param>
         /// <returns>A response that represents whether or not the request was successful.</returns>
-        public async Task<bool> RestoreOrderFromOnHoldAsync(int orderId)
+        public async Task<bool> RestoreOrderFromOnHoldAsync(long orderId)
         {
             var restoreOrderRequest = new JObject();
             restoreOrderRequest["orderId"] = orderId;
@@ -338,7 +338,7 @@ namespace ShipStation4Net.Clients
         /// <param name="orderIds">Identifies set of orders that will have the user unassigned. Please note that if ANY of the orders 
         /// within the array are not found, then no orders will have their users unassigned.</param>
         /// <returns>A response that represents whether or not the request was successful.</returns>
-        public async Task<bool> UnassignUserFromOrderAsync(IList<int> orderIds)
+        public async Task<bool> UnassignUserFromOrderAsync(IList<long> orderIds)
         {
             var unassignUserRequest = new JObject();
             unassignUserRequest["orderIds"] = new JArray(orderIds);

--- a/ShipStation4Net/Clients/Products.cs
+++ b/ShipStation4Net/Clients/Products.cs
@@ -26,7 +26,7 @@ using ShipStation4Net.Responses;
 
 namespace ShipStation4Net.Clients
 {
-    public class Products : ClientBase, IGets<Product>, IUpdates<Product>, IGetsPaginatedResponses<Product, ProductsFilter>
+    public class Products : ClientBase, IGets<Product, int>, IUpdates<Product>, IGetsPaginatedResponses<Product, ProductsFilter>
     {
         public Products(Configuration configuration) : base(configuration)
         {

--- a/ShipStation4Net/Clients/Stores.cs
+++ b/ShipStation4Net/Clients/Stores.cs
@@ -26,7 +26,7 @@ using System.Collections.Generic;
 
 namespace ShipStation4Net.Clients
 {
-    public class Stores : ClientBase, IGets<Store>, IUpdates<Store>
+    public class Stores : ClientBase, IGets<Store, int>, IUpdates<Store>
     {
         public Stores(Configuration configuration) : base(configuration)
         {

--- a/ShipStation4Net/Clients/Warehouses.cs
+++ b/ShipStation4Net/Clients/Warehouses.cs
@@ -23,7 +23,7 @@ using System.Threading.Tasks;
 
 namespace ShipStation4Net.Clients
 {
-    public class Warehouses : ClientBase, IListsItems<Warehouse>, IGets<Warehouse>, IUpdates<Warehouse>, ICreates<Warehouse>, IDeletes<Warehouse>
+    public class Warehouses : ClientBase, IListsItems<Warehouse>, IGets<Warehouse, int>, IUpdates<Warehouse>, ICreates<Warehouse>, IDeletes<Warehouse, int>
     {
         public Warehouses(Configuration configuration) : base(configuration)
         {

--- a/ShipStation4Net/Domain/Entities/Fulfillment.cs
+++ b/ShipStation4Net/Domain/Entities/Fulfillment.cs
@@ -27,7 +27,7 @@ namespace ShipStation4Net.Domain.Entities
 		public int? FulfillmentId { get; set; }
 
 		[JsonProperty("orderId")]
-		public int? OrderId { get; set; }
+		public long? OrderId { get; set; }
 
 		[JsonProperty("orderNumber")]
 		public string OrderNumber { get; set; }

--- a/ShipStation4Net/Domain/Entities/MarkOrderAsShippedRequest.cs
+++ b/ShipStation4Net/Domain/Entities/MarkOrderAsShippedRequest.cs
@@ -26,7 +26,7 @@ namespace ShipStation4Net.Domain.Entities
         /// Identifies the order that will be marked as shipped.
         /// </summary>
         [JsonProperty("orderId")]
-        public int OrderId { get; set; }
+        public long OrderId { get; set; }
 
         /// <summary>
         /// Code of the carrier that is marked as having shipped the order.

--- a/ShipStation4Net/Domain/Entities/Order.cs
+++ b/ShipStation4Net/Domain/Entities/Order.cs
@@ -29,7 +29,7 @@ namespace ShipStation4Net.Domain.Entities
         /// The system generated identifier for the order. This is a read-only field.
         /// </summary>
         [JsonProperty("orderId")]
-        public int? OrderId { get; set; }
+        public long? OrderId { get; set; }
 
         /// <summary>
         /// A user-defined order number used to identify an order.

--- a/ShipStation4Net/Domain/Entities/Shipment.cs
+++ b/ShipStation4Net/Domain/Entities/Shipment.cs
@@ -29,7 +29,7 @@ namespace ShipStation4Net.Domain.Entities
         public int? ShipmentId { get; set; }
 
         [JsonProperty("orderId")]
-        public int? OrderId { get; set; }
+        public long? OrderId { get; set; }
 
         [JsonProperty("userId")]
         public string UserId { get; set; }

--- a/ShipStation4Net/Filters/FulfillmentsFilter.cs
+++ b/ShipStation4Net/Filters/FulfillmentsFilter.cs
@@ -32,7 +32,7 @@ namespace ShipStation4Net.Filters
         /// <summary>
         /// Returns fulfillments whose orders have the specified order ID.
         /// </summary>
-        public int? OrderId { get; set; }
+        public long? OrderId { get; set; }
 
         /// <summary>
         /// Returns fulfillments whose orders have the specified order number.

--- a/ShipStation4Net/Filters/ShipmentsFilter.cs
+++ b/ShipStation4Net/Filters/ShipmentsFilter.cs
@@ -42,7 +42,7 @@ namespace ShipStation4Net.Filters
         /// <summary>
         /// Returns shipments whose orders have the specified order ID.
         /// </summary>
-        public int? OrderId { get; set; }
+        public long? OrderId { get; set; }
 
         /// <summary>
         /// Returns shipments shipped with the specified carrier.

--- a/ShipStation4Net/Responses/MarkOrderAsShippedResponse.cs
+++ b/ShipStation4Net/Responses/MarkOrderAsShippedResponse.cs
@@ -23,7 +23,7 @@ namespace ShipStation4Net.Responses
     public class MarkOrderAsShippedResponse
     {
         [JsonProperty("orderId")]
-        public int OrderId { get; set; }
+        public long OrderId { get; set; }
 
         [JsonProperty("orderNumber")]
         public string OrderNumber { get; set; }

--- a/ShipStation4Net/Responses/UpdateMultipleOrdersResponseItem.cs
+++ b/ShipStation4Net/Responses/UpdateMultipleOrdersResponseItem.cs
@@ -23,7 +23,7 @@ namespace ShipStation4Net.Responses
     public class UpdateMultipleOrdersResponseItem
     {
         [JsonProperty("orderId")]
-        public int? OrderId { get; set; }
+        public long? OrderId { get; set; }
 
         [JsonProperty("orderNumber")]
         public string OrderNumber { get; set; }

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,6 @@
+#### 1.0.11 - 17.05.2024
+* Switch Order.OrderId to be long instead of int
+
 #### 1.0.10 - 15.03.2024
 * Adjusted ShipmentItem.OrderItemId as well
 


### PR DESCRIPTION
ShipStation is currently upgrading its OrderId to 64-bit and recommends making necessary changes.
More details: [ShipStation System Upgrade to 64-bit](https://help.shipstation.com/hc/en-us/articles/25360680030619-ShipStation-System-Upgrade-to-64-bit?utm_campaign=North%20America%20One-Off%20and%20Automated%20Emails&utm_medium=email&_hsenc=p2ANqtz-9UhOoifrYo3eNWY84bieRQ83lpLi8lINkLDo29P2puoIBYB47cgKA01U6rIubBbnq89ONK_IZ_Vzj-n10a__q4MI4UEr87CgLkY9jYQn6YBaSi1Xs&_hsmi=305883121&utm_content=305883121&utm_source=hs_email)